### PR TITLE
fix bug in ip_oldstyle() printf format string

### DIFF
--- a/f5_bigip_decoder.sh
+++ b/f5_bigip_decoder.sh
@@ -114,7 +114,7 @@ ip_oldstyle() {
 	local a b c d
 
 	tmp="${1/%.*}"					# until first dot
-	tmp="$(printf "%x8" "$tmp")"		# convert the whole thing to hex, now back to ip (reversed notation:
+	tmp="$(printf "%08x" "$tmp")"		# convert the whole thing to hex, now back to ip (reversed notation:
 	tmp="$(hex2ip $tmp)"			# transform to ip with reversed notation
 	IFS="." read -r a b c d <<< "$tmp" # reverse it
 	echo $d.$c.$b.$a


### PR DESCRIPTION
The printf format string in `ip_oldstyle()` is incorrect. It works most of the time, but in cases where the hexadecimal output is less than 8 characters, it fails. The "BIGipServer_bar" cookie in the test cases is a perfect example of where this fails. The current version decodes this cookie to 8.140.74.177, but it should decode to 192.168.20.11.